### PR TITLE
docs: add package descriptions

### DIFF
--- a/internal/delivery/doc.go
+++ b/internal/delivery/doc.go
@@ -1,0 +1,2 @@
+// Package delivery provides transport layer handlers such as HTTP and Telegram.
+package delivery

--- a/internal/entity/doc.go
+++ b/internal/entity/doc.go
@@ -1,0 +1,2 @@
+// Package entity defines core domain models.
+package entity

--- a/internal/infrastructure/doc.go
+++ b/internal/infrastructure/doc.go
@@ -1,0 +1,2 @@
+// Package infrastructure provides external API and database clients.
+package infrastructure

--- a/internal/interface/doc.go
+++ b/internal/interface/doc.go
@@ -1,0 +1,2 @@
+// Package ports declares interfaces used by adapters.
+package ports

--- a/internal/usecase/doc.go
+++ b/internal/usecase/doc.go
@@ -1,0 +1,2 @@
+// Package usecase orchestrates business rules.
+package usecase


### PR DESCRIPTION
## Summary
- document internal packages with package comments

## Testing
- `go fmt ./...` *(fails: expected 'package', found 'EOF')*
- `goimports -w .` *(fails: command not found)*
- `staticcheck ./...` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_684547a2315083299556ac22489c3822