### PR TITLE
feat: allow custom dialer for FinageAdapter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/nomenarkt/signalengine
 
 go 1.24.1
+
+require github.com/gorilla/websocket v1.5.3

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/internal/infrastructure/finage_adapter_test.go
+++ b/internal/infrastructure/finage_adapter_test.go
@@ -1,0 +1,37 @@
+package infrastructure
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestNewFinageAdapter_Dialer(t *testing.T) {
+	t.Parallel()
+
+	custom := &websocket.Dialer{HandshakeTimeout: 5 * time.Second}
+
+	tests := []struct {
+		name   string
+		dialer *websocket.Dialer
+		expect *websocket.Dialer
+	}{
+		{name: "default", dialer: nil, expect: websocket.DefaultDialer},
+		{name: "custom", dialer: custom, expect: custom},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := NewFinageAdapter(slog.New(slog.NewTextHandler(io.Discard, nil)), tt.dialer)
+			if a.dialer != tt.expect {
+				t.Fatalf("expected %v, got %v", tt.expect, a.dialer)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add a websocket dialer field to `FinageAdapter`
- allow optional dialer in `NewFinageAdapter`
- use the adapter's dialer in `run`
- test adapter initialization with a custom dialer

## Testing
- `go test ./...`
- `staticcheck ./...`


------
https://chatgpt.com/codex/tasks/task_e_684579f297f48329846d36daa1825702