### PR TITLE
feat(usecase): add RSI divergence scorer

### DIFF
--- a/internal/entity/signal.go
+++ b/internal/entity/signal.go
@@ -1,0 +1,11 @@
+package entity
+
+import "time"
+
+// Signal represents a binary trade setup.
+type Signal struct {
+	Symbol     string
+	Direction  string // "UP" or "DOWN"
+	Confidence float64
+	TTL        time.Duration
+}

--- a/internal/usecase/rsi_divergence_scorer.go
+++ b/internal/usecase/rsi_divergence_scorer.go
@@ -1,0 +1,127 @@
+package usecase
+
+import (
+	"math"
+	"time"
+
+	"github.com/nomenarkt/signalengine/internal/entity"
+	"github.com/nomenarkt/signalengine/internal/ports"
+)
+
+// ScoreRSIDivergence looks for RSI divergence reversal setups over the provided candles and rsi values.
+// It returns binary trade signals with a typical TTL of 2 minutes.
+func ScoreRSIDivergence(symbol string, candles []ports.Candle, rsi []float64) []entity.Signal {
+	n := len(candles)
+	if n < 20 || n != len(rsi) {
+		return nil
+	}
+
+	// Use last 20 bars for analysis
+	start := n - 20
+	c := candles[start:]
+	r := rsi[start:]
+
+	// Find previous swing high/low excluding last 3 bars
+	lookback := len(c) - 3
+	if lookback <= 0 {
+		return nil
+	}
+
+	prevHighIdx, prevLowIdx := 0, 0
+	for i := 1; i < lookback; i++ {
+		if c[i].High > c[prevHighIdx].High {
+			prevHighIdx = i
+		}
+		if c[i].Low < c[prevLowIdx].Low {
+			prevLowIdx = i
+		}
+	}
+
+	latest := len(c) - 1
+	signals := []entity.Signal{}
+
+	// Bearish divergence: price higher high but RSI lower high
+	if c[latest].High > c[prevHighIdx].High && r[latest] < r[prevHighIdx] {
+		if revDir(c[len(c)-3:]) == "DOWN" {
+			signals = append(signals, entity.Signal{
+				Symbol:     symbol,
+				Direction:  "DOWN",
+				Confidence: 0.8,
+				TTL:        2 * time.Minute,
+			})
+		}
+	}
+
+	// Bullish divergence: price lower low but RSI higher low
+	if c[latest].Low < c[prevLowIdx].Low && r[latest] > r[prevLowIdx] {
+		if revDir(c[len(c)-3:]) == "UP" {
+			signals = append(signals, entity.Signal{
+				Symbol:     symbol,
+				Direction:  "UP",
+				Confidence: 0.8,
+				TTL:        2 * time.Minute,
+			})
+		}
+	}
+
+	return signals
+}
+
+// revDir checks the last up to 3 candles for a reversal pattern and returns "UP", "DOWN", or "".
+func revDir(c []ports.Candle) string {
+	n := len(c)
+	for i := n - 1; i >= 0; i-- {
+		if isBullishEngulfing(c, i) || isBullishPinBar(c[i]) {
+			return "UP"
+		}
+		if isBearishEngulfing(c, i) || isBearishPinBar(c[i]) {
+			return "DOWN"
+		}
+	}
+	return ""
+}
+
+func body(c ports.Candle) float64      { return math.Abs(c.Close - c.Open) }
+func rangeSize(c ports.Candle) float64 { return c.High - c.Low }
+
+func isBullishPinBar(c ports.Candle) bool {
+	r := rangeSize(c)
+	if r == 0 {
+		return false
+	}
+	lowerWick := math.Min(c.Open, c.Close) - c.Low
+	return body(c) <= r/3 && lowerWick >= r*2/3
+}
+
+func isBearishPinBar(c ports.Candle) bool {
+	r := rangeSize(c)
+	if r == 0 {
+		return false
+	}
+	upperWick := c.High - math.Max(c.Open, c.Close)
+	return body(c) <= r/3 && upperWick >= r*2/3
+}
+
+func isBullishEngulfing(c []ports.Candle, i int) bool {
+	if i == 0 {
+		return false
+	}
+	p := c[i-1]
+	cur := c[i]
+	if cur.Close <= cur.Open || p.Close >= p.Open {
+		return false
+	}
+	return cur.Open < p.Close && cur.Close > p.Open
+}
+
+func isBearishEngulfing(c []ports.Candle, i int) bool {
+	if i == 0 {
+		return false
+	}
+	p := c[i-1]
+	cur := c[i]
+	if cur.Close >= cur.Open || p.Close <= p.Open {
+		return false
+	}
+	return cur.Open > p.Close && cur.Close < p.Open
+}

--- a/internal/usecase/rsi_divergence_scorer_test.go
+++ b/internal/usecase/rsi_divergence_scorer_test.go
@@ -1,0 +1,77 @@
+package usecase
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nomenarkt/signalengine/internal/ports"
+)
+
+func TestScoreRSIDivergence(t *testing.T) {
+	baseTime := time.Now()
+
+	makeCandles := func(lastBullish bool) ([]ports.Candle, []float64) {
+		candles := make([]ports.Candle, 20)
+		rsi := make([]float64, 20)
+		for i := 0; i < 20; i++ {
+			candles[i] = ports.Candle{
+				Symbol: "EURUSD",
+				Time:   baseTime.Add(time.Duration(i) * time.Minute),
+				Open:   1,
+				High:   1,
+				Low:    1,
+				Close:  1,
+			}
+			rsi[i] = 50 - float64(i)
+		}
+		// previous swing low at index 16
+		candles[16].Open = 0.7
+		candles[16].High = 0.8
+		candles[16].Low = 0.5
+		candles[16].Close = 0.6
+		rsi[16] = 30
+
+		candles[17].Open = 0.65
+		candles[17].High = 0.75
+		candles[17].Low = 0.55
+		candles[17].Close = 0.6
+		rsi[17] = 32
+
+		candles[18].Open = 0.6
+		candles[18].High = 0.65
+		candles[18].Low = 0.45
+		candles[18].Close = 0.5
+		rsi[18] = 31
+
+		candles[19].Open = 0.48
+		candles[19].High = 0.9
+		candles[19].Low = 0.4
+		if lastBullish {
+			candles[19].Close = 0.8 // bullish engulfing
+		} else {
+			candles[19].Close = 0.45 // bearish continuation
+		}
+		rsi[19] = 40
+		return candles, rsi
+	}
+
+	t.Run("bullish divergence with reversal", func(t *testing.T) {
+		candles, r := makeCandles(true)
+		sigs := ScoreRSIDivergence("EURUSD", candles, r)
+		if len(sigs) != 1 {
+			t.Fatalf("expected 1 signal, got %d", len(sigs))
+		}
+		s := sigs[0]
+		if s.Direction != "UP" {
+			t.Errorf("expected UP, got %s", s.Direction)
+		}
+	})
+
+	t.Run("no signal without reversal candle", func(t *testing.T) {
+		candles, r := makeCandles(false)
+		sigs := ScoreRSIDivergence("EURUSD", candles, r)
+		if len(sigs) != 0 {
+			t.Fatalf("expected no signals, got %d", len(sigs))
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- detect RSI divergence setups
- add signal domain model
- test RSI divergence scoring function

## Testing
- `~/go/bin/staticcheck ./...` *(fails: module requires at least go1.24.1, but Staticcheck was built with go1.23.8)*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6845b11d2fe48329b1a3b385ba583e9c