### PR TITLE
feat(delivery): add telegram signal formatter

### DIFF
--- a/internal/delivery/telegram_formatter.go
+++ b/internal/delivery/telegram_formatter.go
@@ -1,0 +1,45 @@
+package delivery
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/nomenarkt/signalengine/internal/entity"
+)
+
+// FormatSignals converts trade signals into formatted strings suitable for
+// Telegram notifications. Each signal is represented as a multi-line message.
+func FormatSignals(signals []entity.Signal) []string {
+	if len(signals) == 0 {
+		return nil
+	}
+
+	out := make([]string, 0, len(signals))
+	for _, s := range signals {
+		symbol := strings.ToUpper(s.Symbol)
+
+		confidence := int(math.Round((s.Confidence*100)/5) * 5)
+		if confidence > 100 {
+			confidence = 100
+		} else if confidence < 0 {
+			confidence = 0
+		}
+
+		minutes := int(s.TTL.Round(time.Minute) / time.Minute)
+		if minutes < 1 {
+			minutes = 1
+		}
+
+		msg := fmt.Sprintf(
+			"⚡ Signal: %s\n📈 Direction: %s\n🎯 Confidence: %d%%\n⏱️ Expires in: %dm",
+			symbol,
+			strings.ToUpper(s.Direction),
+			confidence,
+			minutes,
+		)
+		out = append(out, msg)
+	}
+	return out
+}

--- a/internal/delivery/telegram_formatter_test.go
+++ b/internal/delivery/telegram_formatter_test.go
@@ -1,0 +1,49 @@
+package delivery
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/nomenarkt/signalengine/internal/entity"
+)
+
+func TestFormatSignals(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []entity.Signal
+		want  []string
+	}{
+		{
+			name:  "single signal",
+			input: []entity.Signal{{Symbol: "eurusd", Direction: "up", Confidence: 0.83, TTL: 2 * time.Minute}},
+			want:  []string{"⚡ Signal: EURUSD\n📈 Direction: UP\n🎯 Confidence: 85%\n⏱️ Expires in: 2m"},
+		},
+		{
+			name: "multiple signals",
+			input: []entity.Signal{
+				{Symbol: "gbpusd", Direction: "down", Confidence: 0.7, TTL: 5 * time.Minute},
+				{Symbol: "usdchf", Direction: "UP", Confidence: 0.92, TTL: 1 * time.Minute},
+			},
+			want: []string{
+				"⚡ Signal: GBPUSD\n📈 Direction: DOWN\n🎯 Confidence: 70%\n⏱️ Expires in: 5m",
+				"⚡ Signal: USDCHF\n📈 Direction: UP\n🎯 Confidence: 90%\n⏱️ Expires in: 1m",
+			},
+		},
+		{
+			name:  "empty",
+			input: nil,
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatSignals(tt.input)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- implement FormatSignals for telegram message formatting
- cover FormatSignals with unit tests

## Testing
- `go fmt ./...`
- `staticcheck ./...` *(fails: module requires go1.24.1 but staticcheck built with go1.23.8)*
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6845b58a28e88329adce166d30e9c45f