### PR TITLE
feat(delivery): add telegram orchestrator

### DIFF
--- a/internal/delivery/orchestrator.go
+++ b/internal/delivery/orchestrator.go
@@ -1,0 +1,111 @@
+package delivery
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/nomenarkt/signalengine/internal/ports"
+	"github.com/nomenarkt/signalengine/internal/usecase"
+)
+
+// Orchestrator streams market data, scores signals and publishes alerts.
+type Orchestrator struct {
+	feed      ports.MarketFeedPort
+	publisher ports.TelegramPublisher
+	logger    *slog.Logger
+}
+
+// NewOrchestrator initializes an Orchestrator.
+func NewOrchestrator(feed ports.MarketFeedPort, pub ports.TelegramPublisher, logger *slog.Logger) *Orchestrator {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Orchestrator{feed: feed, publisher: pub, logger: logger}
+}
+
+// Run starts streaming candles for the given symbols and processes signals.
+func (o *Orchestrator) Run(ctx context.Context, symbols []string) error {
+	ch, err := o.feed.StreamCandles(ctx, symbols)
+	if err != nil {
+		return err
+	}
+
+	const (
+		keepBars  = 50
+		rsiPeriod = 14
+	)
+
+	data := make(map[string][]ports.Candle)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case c, ok := <-ch:
+			if !ok {
+				return nil
+			}
+			candles := append(data[c.Symbol], c)
+			if len(candles) > keepBars {
+				candles = candles[len(candles)-keepBars:]
+			}
+			data[c.Symbol] = candles
+			if len(candles) < 20 {
+				continue
+			}
+			closes := make([]float64, len(candles))
+			for i := range candles {
+				closes[i] = candles[i].Close
+			}
+			rsi := calcRSI(closes, rsiPeriod)
+			signals := usecase.ScoreRSIDivergence(c.Symbol, candles, rsi)
+			if len(signals) == 0 {
+				continue
+			}
+			msgs := FormatSignals(signals)
+			if err := o.publisher.PublishMessages(ctx, msgs); err != nil {
+				o.logger.ErrorContext(ctx, "publish telegram", "error", err)
+			}
+		}
+	}
+}
+
+func calcRSI(closes []float64, period int) []float64 {
+	rsi := make([]float64, len(closes))
+	if len(closes) <= period {
+		return rsi
+	}
+	var gain, loss float64
+	for i := 1; i <= period; i++ {
+		diff := closes[i] - closes[i-1]
+		if diff > 0 {
+			gain += diff
+		} else {
+			loss -= diff
+		}
+	}
+	avgGain := gain / float64(period)
+	avgLoss := loss / float64(period)
+	if avgLoss == 0 {
+		rsi[period] = 100
+	} else {
+		rs := avgGain / avgLoss
+		rsi[period] = 100 - 100/(1+rs)
+	}
+	for i := period + 1; i < len(closes); i++ {
+		diff := closes[i] - closes[i-1]
+		if diff > 0 {
+			avgGain = (avgGain*float64(period-1) + diff) / float64(period)
+			avgLoss = (avgLoss * float64(period-1)) / float64(period)
+		} else {
+			avgGain = (avgGain * float64(period-1)) / float64(period)
+			avgLoss = (avgLoss*float64(period-1) - diff) / float64(period)
+		}
+		if avgLoss == 0 {
+			rsi[i] = 100
+		} else {
+			rs := avgGain / avgLoss
+			rsi[i] = 100 - 100/(1+rs)
+		}
+	}
+	return rsi
+}

--- a/internal/delivery/orchestrator_test.go
+++ b/internal/delivery/orchestrator_test.go
@@ -1,0 +1,78 @@
+package delivery
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/nomenarkt/signalengine/internal/ports"
+)
+
+type mockFeed struct{ candles []ports.Candle }
+
+func (m *mockFeed) StreamCandles(ctx context.Context, symbols []string) (<-chan ports.Candle, error) {
+	ch := make(chan ports.Candle)
+	go func() {
+		defer close(ch)
+		for _, c := range m.candles {
+			select {
+			case <-ctx.Done():
+				return
+			case ch <- c:
+			}
+		}
+	}()
+	return ch, nil
+}
+
+type mockPublisher struct{ msgs []string }
+
+func (m *mockPublisher) PublishMessages(ctx context.Context, msgs []string) error {
+	m.msgs = append(m.msgs, msgs...)
+	return nil
+}
+
+func makeCandles(bullish bool) []ports.Candle {
+	base := time.Now()
+	var candles []ports.Candle
+	for i := 0; i < 16; i++ {
+		candles = append(candles, ports.Candle{Symbol: "EURUSD", Time: base.Add(time.Duration(i) * time.Minute), Open: 1, High: 1, Low: 1, Close: 1})
+	}
+	candles = append(candles, ports.Candle{Symbol: "EURUSD", Time: base.Add(16 * time.Minute), Open: 0.7, High: 0.8, Low: 0.5, Close: 0.6})
+	candles = append(candles, ports.Candle{Symbol: "EURUSD", Time: base.Add(17 * time.Minute), Open: 0.65, High: 0.75, Low: 0.55, Close: 0.6})
+	candles = append(candles, ports.Candle{Symbol: "EURUSD", Time: base.Add(18 * time.Minute), Open: 0.6, High: 0.65, Low: 0.45, Close: 0.5})
+	lastClose := 0.45
+	if bullish {
+		lastClose = 0.8
+	}
+	candles = append(candles, ports.Candle{Symbol: "EURUSD", Time: base.Add(19 * time.Minute), Open: 0.48, High: 0.9, Low: 0.4, Close: lastClose})
+	return candles
+}
+
+func TestOrchestrator_Run(t *testing.T) {
+	tests := []struct {
+		name    string
+		bullish bool
+		expect  int
+	}{
+		{name: "signal", bullish: true, expect: 1},
+		{name: "no signal", bullish: false, expect: 0},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			feed := &mockFeed{candles: makeCandles(tt.bullish)}
+			pub := &mockPublisher{}
+			o := NewOrchestrator(feed, pub, slog.New(slog.NewTextHandler(io.Discard, nil)))
+			if err := o.Run(ctx, []string{"EURUSD"}); err != nil {
+				t.Fatalf("run: %v", err)
+			}
+			if len(pub.msgs) != tt.expect {
+				t.Fatalf("expected %d messages, got %d", tt.expect, len(pub.msgs))
+			}
+		})
+	}
+}

--- a/internal/ports/telegrampublisher.go
+++ b/internal/ports/telegrampublisher.go
@@ -1,0 +1,9 @@
+package ports
+
+import "context"
+
+// TelegramPublisher publishes messages to Telegram.
+type TelegramPublisher interface {
+	// PublishMessages sends the provided messages as Telegram alerts.
+	PublishMessages(ctx context.Context, msgs []string) error
+}


### PR DESCRIPTION
## Summary
- publish trade signals via Telegram
- orchestrate market data and scoring
- expose TelegramPublisher port
- test orchestration flow

## Testing
- `staticcheck ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6845c3689e1c8329bd7b7241040ddf4f