### PR TITLE
feat(usecase): log RSI divergence scoring

### DIFF
--- a/internal/delivery/orchestrator.go
+++ b/internal/delivery/orchestrator.go
@@ -57,7 +57,7 @@ func (o *Orchestrator) Run(ctx context.Context, symbols []string) error {
 				closes[i] = candles[i].Close
 			}
 			rsi := calcRSI(closes, rsiPeriod)
-			signals := usecase.ScoreRSIDivergence(c.Symbol, candles, rsi)
+			signals := usecase.ScoreRSIDivergence(ctx, o.logger, c.Symbol, candles, rsi)
 			if len(signals) == 0 {
 				continue
 			}

--- a/internal/usecase/rsi_divergence_scorer.go
+++ b/internal/usecase/rsi_divergence_scorer.go
@@ -1,6 +1,8 @@
 package usecase
 
 import (
+	"context"
+	"log/slog"
 	"math"
 	"time"
 
@@ -10,9 +12,15 @@ import (
 
 // ScoreRSIDivergence looks for RSI divergence reversal setups over the provided candles and rsi values.
 // It returns binary trade signals with a typical TTL of 2 minutes.
-func ScoreRSIDivergence(symbol string, candles []ports.Candle, rsi []float64) []entity.Signal {
+func ScoreRSIDivergence(ctx context.Context, logger *slog.Logger, symbol string, candles []ports.Candle, rsi []float64) []entity.Signal {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	logger.InfoContext(ctx, "score RSI divergence", "symbol", symbol)
+
 	n := len(candles)
 	if n < 20 || n != len(rsi) {
+		logger.WarnContext(ctx, "insufficient data", "candles", n, "rsi_len", len(rsi))
 		return nil
 	}
 
@@ -24,6 +32,7 @@ func ScoreRSIDivergence(symbol string, candles []ports.Candle, rsi []float64) []
 	// Find previous swing high/low excluding last 3 bars
 	lookback := len(c) - 3
 	if lookback <= 0 {
+		logger.WarnContext(ctx, "insufficient candles for swing lookup")
 		return nil
 	}
 

--- a/internal/usecase/rsi_divergence_scorer_test.go
+++ b/internal/usecase/rsi_divergence_scorer_test.go
@@ -1,6 +1,9 @@
 package usecase
 
 import (
+	"context"
+	"io"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -55,9 +58,12 @@ func TestScoreRSIDivergence(t *testing.T) {
 		return candles, rsi
 	}
 
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
 	t.Run("bullish divergence with reversal", func(t *testing.T) {
 		candles, r := makeCandles(true)
-		sigs := ScoreRSIDivergence("EURUSD", candles, r)
+		sigs := ScoreRSIDivergence(ctx, logger, "EURUSD", candles, r)
 		if len(sigs) != 1 {
 			t.Fatalf("expected 1 signal, got %d", len(sigs))
 		}
@@ -69,7 +75,7 @@ func TestScoreRSIDivergence(t *testing.T) {
 
 	t.Run("no signal without reversal candle", func(t *testing.T) {
 		candles, r := makeCandles(false)
-		sigs := ScoreRSIDivergence("EURUSD", candles, r)
+		sigs := ScoreRSIDivergence(ctx, logger, "EURUSD", candles, r)
 		if len(sigs) != 0 {
 			t.Fatalf("expected no signals, got %d", len(sigs))
 		}


### PR DESCRIPTION
## Summary
- log entry and early returns for ScoreRSIDivergence
- pass logger through orchestrator
- update tests for scorer changes

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6845c5c5a2148329b576608d4f3daaf5