### PR TITLE
feat(usecase): extract RSI calculator

### DIFF
--- a/internal/delivery/orchestrator.go
+++ b/internal/delivery/orchestrator.go
@@ -56,7 +56,7 @@ func (o *Orchestrator) Run(ctx context.Context, symbols []string) error {
 			for i := range candles {
 				closes[i] = candles[i].Close
 			}
-			rsi := calcRSI(closes, rsiPeriod)
+			rsi := usecase.CalcRSI(closes, rsiPeriod)
 			signals := usecase.ScoreRSIDivergence(ctx, o.logger, c.Symbol, candles, rsi)
 			if len(signals) == 0 {
 				continue
@@ -67,45 +67,4 @@ func (o *Orchestrator) Run(ctx context.Context, symbols []string) error {
 			}
 		}
 	}
-}
-
-func calcRSI(closes []float64, period int) []float64 {
-	rsi := make([]float64, len(closes))
-	if len(closes) <= period {
-		return rsi
-	}
-	var gain, loss float64
-	for i := 1; i <= period; i++ {
-		diff := closes[i] - closes[i-1]
-		if diff > 0 {
-			gain += diff
-		} else {
-			loss -= diff
-		}
-	}
-	avgGain := gain / float64(period)
-	avgLoss := loss / float64(period)
-	if avgLoss == 0 {
-		rsi[period] = 100
-	} else {
-		rs := avgGain / avgLoss
-		rsi[period] = 100 - 100/(1+rs)
-	}
-	for i := period + 1; i < len(closes); i++ {
-		diff := closes[i] - closes[i-1]
-		if diff > 0 {
-			avgGain = (avgGain*float64(period-1) + diff) / float64(period)
-			avgLoss = (avgLoss * float64(period-1)) / float64(period)
-		} else {
-			avgGain = (avgGain * float64(period-1)) / float64(period)
-			avgLoss = (avgLoss*float64(period-1) - diff) / float64(period)
-		}
-		if avgLoss == 0 {
-			rsi[i] = 100
-		} else {
-			rs := avgGain / avgLoss
-			rsi[i] = 100 - 100/(1+rs)
-		}
-	}
-	return rsi
 }

--- a/internal/usecase/rsi.go
+++ b/internal/usecase/rsi.go
@@ -1,0 +1,45 @@
+package usecase
+
+// CalcRSI calculates the Relative Strength Index for the provided closing prices.
+// The returned slice has the same length as closes. Values before the given
+// period remain zero.
+func CalcRSI(closes []float64, period int) []float64 {
+	rsi := make([]float64, len(closes))
+	if len(closes) <= period {
+		return rsi
+	}
+	var gain, loss float64
+	for i := 1; i <= period; i++ {
+		diff := closes[i] - closes[i-1]
+		if diff > 0 {
+			gain += diff
+		} else {
+			loss -= diff
+		}
+	}
+	avgGain := gain / float64(period)
+	avgLoss := loss / float64(period)
+	if avgLoss == 0 {
+		rsi[period] = 100
+	} else {
+		rs := avgGain / avgLoss
+		rsi[period] = 100 - 100/(1+rs)
+	}
+	for i := period + 1; i < len(closes); i++ {
+		diff := closes[i] - closes[i-1]
+		if diff > 0 {
+			avgGain = (avgGain*float64(period-1) + diff) / float64(period)
+			avgLoss = (avgLoss * float64(period-1)) / float64(period)
+		} else {
+			avgGain = (avgGain * float64(period-1)) / float64(period)
+			avgLoss = (avgLoss*float64(period-1) - diff) / float64(period)
+		}
+		if avgLoss == 0 {
+			rsi[i] = 100
+		} else {
+			rs := avgGain / avgLoss
+			rsi[i] = 100 - 100/(1+rs)
+		}
+	}
+	return rsi
+}

--- a/internal/usecase/rsi_test.go
+++ b/internal/usecase/rsi_test.go
@@ -1,0 +1,17 @@
+package usecase
+
+import "testing"
+
+func TestCalcRSI(t *testing.T) {
+	closes := []float64{1, 2, 1, 2, 1, 2, 1}
+	want := []float64{0, 0, 50, 75, 37.5, 68.75, 34.375}
+	got := CalcRSI(closes, 2)
+	if len(got) != len(want) {
+		t.Fatalf("length mismatch: got %d want %d", len(got), len(want))
+	}
+	for i := range want {
+		if diff := got[i] - want[i]; diff > 1e-9 || diff < -1e-9 {
+			t.Errorf("index %d: want %.5f got %.5f", i, want[i], got[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- move RSI calculation to usecase as CalcRSI
- use the new CalcRSI in orchestrator
- update orchestrator tests
- add unit test for CalcRSI

## Testing
- `go test ./...`
- `staticcheck ./...`

------
https://chatgpt.com/codex/tasks/task_e_6845cfa32694832981f74d4d97ed57b4