### PR TITLE
test: add orchestrator reconnection harness

### DIFF
--- a/internal/delivery/orchestrator_harness_test.go
+++ b/internal/delivery/orchestrator_harness_test.go
@@ -1,0 +1,71 @@
+package delivery
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/nomenarkt/signalengine/internal/ports"
+	"github.com/nomenarkt/signalengine/internal/testutils"
+	"github.com/nomenarkt/signalengine/internal/usecase"
+)
+
+func expectedSignals(ctx context.Context, candles []ports.Candle) int {
+	const keepBars = 50
+	const rsiPeriod = 14
+
+	data := make([]ports.Candle, 0, keepBars)
+	count := 0
+	for _, c := range candles {
+		data = append(data, c)
+		if len(data) > keepBars {
+			data = data[len(data)-keepBars:]
+		}
+		if len(data) < 20 {
+			continue
+		}
+		closes := make([]float64, len(data))
+		for i := range data {
+			closes[i] = data[i].Close
+		}
+		rsi := usecase.CalcRSI(closes, rsiPeriod)
+		signals := usecase.ScoreRSIDivergence(ctx, slog.New(slog.NewTextHandler(io.Discard, nil)), c.Symbol, data, rsi)
+		count += len(signals)
+	}
+	return count
+}
+
+func TestOrchestrator_ReconnectPublish(t *testing.T) {
+	ctx := context.Background()
+
+	seq := testutils.MakeCandles(true)
+	feed := &testutils.MockMarketFeed{Sequences: [][]ports.Candle{seq, seq}, Delay: 10 * time.Millisecond}
+	pub := &testutils.MockPublisher{FailFirst: true}
+	o := NewOrchestrator(feed, pub, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	if err := o.Run(ctx, []string{"EURUSD"}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	got := 0
+	for _, m := range pub.Messages {
+		got += len(m)
+	}
+
+	all := append(append([]ports.Candle{}, seq...), seq...)
+	want := expectedSignals(ctx, all)
+
+	if got != want {
+		t.Fatalf("expected %d messages, got %d", want, got)
+	}
+
+	if pub.Calls != len(pub.Messages) {
+		t.Fatalf("expected %d publish calls, got %d", len(pub.Messages), pub.Calls)
+	}
+
+	if pub.Calls == 0 {
+		t.Fatalf("expected publisher to be called")
+	}
+}

--- a/internal/testutils/candles.go
+++ b/internal/testutils/candles.go
@@ -1,0 +1,25 @@
+package testutils
+
+import (
+	"time"
+
+	"github.com/nomenarkt/signalengine/internal/ports"
+)
+
+// MakeCandles returns a slice of candles forming either a bullish or neutral pattern.
+func MakeCandles(bullish bool) []ports.Candle {
+	base := time.Now()
+	var candles []ports.Candle
+	for i := 0; i < 16; i++ {
+		candles = append(candles, ports.Candle{Symbol: "EURUSD", Time: base.Add(time.Duration(i) * time.Minute), Open: 1, High: 1, Low: 1, Close: 1})
+	}
+	candles = append(candles, ports.Candle{Symbol: "EURUSD", Time: base.Add(16 * time.Minute), Open: 0.7, High: 0.8, Low: 0.5, Close: 0.6})
+	candles = append(candles, ports.Candle{Symbol: "EURUSD", Time: base.Add(17 * time.Minute), Open: 0.65, High: 0.75, Low: 0.55, Close: 0.6})
+	candles = append(candles, ports.Candle{Symbol: "EURUSD", Time: base.Add(18 * time.Minute), Open: 0.6, High: 0.65, Low: 0.45, Close: 0.5})
+	lastClose := 0.45
+	if bullish {
+		lastClose = 0.8
+	}
+	candles = append(candles, ports.Candle{Symbol: "EURUSD", Time: base.Add(19 * time.Minute), Open: 0.48, High: 0.9, Low: 0.4, Close: lastClose})
+	return candles
+}

--- a/internal/testutils/mock_feed.go
+++ b/internal/testutils/mock_feed.go
@@ -1,0 +1,40 @@
+package testutils
+
+import (
+	"context"
+	"time"
+
+	"github.com/nomenarkt/signalengine/internal/ports"
+)
+
+// MockMarketFeed streams predefined candle sequences with optional delays between sequences.
+type MockMarketFeed struct {
+	Sequences [][]ports.Candle
+	Delay     time.Duration
+}
+
+// StreamCandles returns a channel that emits the configured candle sequences.
+// The channel closes when all sequences are sent or the context is canceled.
+func (m *MockMarketFeed) StreamCandles(ctx context.Context, symbols []string) (<-chan ports.Candle, error) {
+	ch := make(chan ports.Candle)
+	go func() {
+		defer close(ch)
+		for i, seq := range m.Sequences {
+			for _, c := range seq {
+				select {
+				case <-ctx.Done():
+					return
+				case ch <- c:
+				}
+			}
+			if i < len(m.Sequences)-1 && m.Delay > 0 {
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(m.Delay):
+				}
+			}
+		}
+	}()
+	return ch, nil
+}

--- a/internal/testutils/mock_publisher.go
+++ b/internal/testutils/mock_publisher.go
@@ -1,0 +1,27 @@
+package testutils
+
+import (
+	"context"
+	"errors"
+
+	"github.com/nomenarkt/signalengine/internal/ports"
+)
+
+// MockPublisher records published messages and can simulate transient failures.
+type MockPublisher struct {
+	FailFirst bool
+	Calls     int
+	Messages  [][]string
+}
+
+// PublishMessages appends messages and optionally returns an error on the first call.
+func (m *MockPublisher) PublishMessages(ctx context.Context, msgs []string) error {
+	m.Calls++
+	m.Messages = append(m.Messages, msgs)
+	if m.FailFirst && m.Calls == 1 {
+		return errors.New("publish error")
+	}
+	return nil
+}
+
+var _ ports.TelegramPublisher = (*MockPublisher)(nil)


### PR DESCRIPTION
## Summary
- add reusable test utilities for candles, market feed, and publisher
- verify Orchestrator continues to publish signals when the feed reconnects

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6845d70287048329aeb89b88c125a6bf