### PR TITLE
feat(usecase): add backtester engine

### DIFF
--- a/internal/usecase/backtester.go
+++ b/internal/usecase/backtester.go
@@ -1,0 +1,146 @@
+package usecase
+
+import (
+	"time"
+
+	"github.com/nomenarkt/signalengine/internal/ports"
+)
+
+// BacktestResult represents the outcome of a single simulated trade.
+type BacktestResult struct {
+	Symbol     string
+	Direction  string
+	EntryTime  time.Time
+	ExpiryTime time.Time
+	Outcome    string
+	Reason     string
+}
+
+// BacktestReport aggregates results from a backtest run.
+type BacktestReport struct {
+	Results  []BacktestResult
+	Accuracy float64
+	Total    int
+	Wins     int
+	Losses   int
+	Neutrals int
+}
+
+// BacktestSignals replays historical candles and evaluates signal outcomes.
+func BacktestSignals(data map[string][]ports.Candle, delayBeforeEntry, expiry time.Duration) BacktestReport {
+	const (
+		windowSize = 50
+		rsiPeriod  = 14
+	)
+
+	var rep BacktestReport
+
+	for symbol, candles := range data {
+		if len(candles) < windowSize || !sorted(candles) {
+			continue
+		}
+
+		for i := windowSize - 1; i < len(candles); i++ {
+			window := candles[i-windowSize+1 : i+1]
+			closes := make([]float64, len(window))
+			for j, c := range window {
+				closes[j] = c.Close
+			}
+
+			rsi := CalcRSI(closes, rsiPeriod)
+			ema8 := calcEMA(closes, 8)
+			ema21 := calcEMA(closes, 21)
+
+			signals := ScanSignalPatterns(symbol, window, rsi, ema8, ema21)
+			if len(signals) == 0 {
+				continue
+			}
+
+			entryIdx := i + int(delayBeforeEntry/time.Minute)
+			exitIdx := entryIdx + int(expiry/time.Minute)
+			if exitIdx >= len(candles) {
+				continue
+			}
+
+			entryTime := candles[entryIdx].Time
+			expiryTime := candles[exitIdx].Time
+			entryClose := candles[entryIdx].Close
+			exitClose := candles[exitIdx].Close
+
+			for _, s := range signals {
+				res := BacktestResult{
+					Symbol:     symbol,
+					Direction:  s.Direction,
+					EntryTime:  entryTime,
+					ExpiryTime: expiryTime,
+				}
+
+				switch s.Direction {
+				case "UP":
+					switch {
+					case exitClose > entryClose:
+						res.Outcome = "WIN"
+						res.Reason = "closed above entry"
+					case exitClose < entryClose:
+						res.Outcome = "LOSS"
+						res.Reason = "closed below entry"
+					default:
+						res.Outcome = "NEUTRAL"
+						res.Reason = "no change"
+					}
+				case "DOWN":
+					switch {
+					case exitClose < entryClose:
+						res.Outcome = "WIN"
+						res.Reason = "closed below entry"
+					case exitClose > entryClose:
+						res.Outcome = "LOSS"
+						res.Reason = "closed above entry"
+					default:
+						res.Outcome = "NEUTRAL"
+						res.Reason = "no change"
+					}
+				}
+
+				rep.Results = append(rep.Results, res)
+				rep.Total++
+				switch res.Outcome {
+				case "WIN":
+					rep.Wins++
+				case "LOSS":
+					rep.Losses++
+				case "NEUTRAL":
+					rep.Neutrals++
+				}
+			}
+		}
+	}
+
+	if rep.Wins+rep.Losses > 0 {
+		rep.Accuracy = float64(rep.Wins) / float64(rep.Wins+rep.Losses)
+	}
+
+	return rep
+}
+
+func sorted(c []ports.Candle) bool {
+	for i := 1; i < len(c); i++ {
+		if c[i].Time.Before(c[i-1].Time) {
+			return false
+		}
+	}
+	return true
+}
+
+func calcEMA(values []float64, period int) []float64 {
+	out := make([]float64, len(values))
+	if len(values) == 0 {
+		return out
+	}
+	k := 2.0 / float64(period+1)
+	out[0] = values[0]
+	for i := 1; i < len(values); i++ {
+		out[i] = values[i]*k + out[i-1]*(1-k)
+	}
+	return out
+}

--- a/internal/usecase/backtester_test.go
+++ b/internal/usecase/backtester_test.go
@@ -1,0 +1,66 @@
+package usecase
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nomenarkt/signalengine/internal/ports"
+	"github.com/nomenarkt/signalengine/internal/testutils"
+)
+
+// makeSeries returns 60 candles with a bullish divergence around index 54.
+// If win is true, the trade closes higher; otherwise lower.
+func makeSeries(sym string, win bool) []ports.Candle {
+	base := time.Now()
+	candles := make([]ports.Candle, 35)
+	for i := 0; i < 35; i++ {
+		ts := base.Add(time.Duration(i) * time.Minute)
+		candles[i] = ports.Candle{Symbol: sym, Time: ts, Open: 1, High: 1, Low: 1, Close: 1}
+	}
+	pattern := testutils.MakeCandles(true)
+	for i, c := range pattern {
+		c.Symbol = sym
+		c.Time = base.Add(time.Duration(35+i) * time.Minute)
+		candles = append(candles, c)
+	}
+	start := len(candles)
+	for i := 0; i < 5; i++ {
+		ts := base.Add(time.Duration(start+i) * time.Minute)
+		close := 1.1 + float64(i)*0.05
+		if !win {
+			close = 0.6 - float64(i)*0.05
+		}
+		candles = append(candles, ports.Candle{Symbol: sym, Time: ts, Open: close, High: close, Low: close, Close: close})
+	}
+	return candles
+}
+
+func TestBacktestSignals_Generate(t *testing.T) {
+	data := map[string][]ports.Candle{
+		"EURUSD": makeSeries("EURUSD", true),
+	}
+	rep := BacktestSignals(data, 3*time.Minute, 2*time.Minute)
+	if rep.Total == 0 {
+		t.Fatalf("expected results")
+	}
+	if rep.Results[0].Outcome == "NEUTRAL" {
+		t.Errorf("expected resolved outcome, got %s", rep.Results[0].Outcome)
+	}
+}
+
+func TestBacktestSignals_ReportCounts(t *testing.T) {
+	data := map[string][]ports.Candle{
+		"WIN":  makeSeries("WIN", true),
+		"LOSS": makeSeries("LOSS", false),
+	}
+	rep := BacktestSignals(data, 3*time.Minute, 2*time.Minute)
+	if rep.Total != 2 {
+		t.Fatalf("want 2 results, got %d", rep.Total)
+	}
+	if rep.Wins != 1 || rep.Losses != 1 || rep.Neutrals != 0 {
+		t.Fatalf("unexpected counts: %+v", rep)
+	}
+	if rep.Accuracy != 0.5 {
+		t.Errorf("want accuracy 0.5, got %v", rep.Accuracy)
+	}
+}


### PR DESCRIPTION
## Summary
- backtest signals over historical candles
- report trade outcomes and accuracy
- cover backtester with unit tests

## Testing
- `go fmt ./...`
- `goimports -w .`
- `go test ./...`
- `staticcheck ./...` *(fails: module requires at least go1.24.1, but Staticcheck was built with go1.23.8)*

------
https://chatgpt.com/codex/tasks/task_e_68470816d83083299032c568db01f0a4