### PR TITLE
feat(delivery): add backtest report exporter

### DIFF
--- a/internal/delivery/signal_statsexporter.go
+++ b/internal/delivery/signal_statsexporter.go
@@ -1,0 +1,80 @@
+package delivery
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/nomenarkt/signalengine/internal/usecase"
+)
+
+// ExportBacktestReport writes the provided BacktestReport to path in the given
+// format. If format is empty, it is inferred from the file extension. Supported
+// formats are "json" and "csv".
+func ExportBacktestReport(rep usecase.BacktestReport, path, format string) (err error) {
+	if len(rep.Results) == 0 {
+		return fmt.Errorf("export report: empty results")
+	}
+
+	if format == "" {
+		ext := strings.ToLower(filepath.Ext(path))
+		switch ext {
+		case ".json":
+			format = "json"
+		case ".csv":
+			format = "csv"
+		default:
+			return fmt.Errorf("export report: unknown format for %s", path)
+		}
+	}
+	format = strings.ToLower(format)
+
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("export report: %w", err)
+	}
+	defer func() {
+		if cerr := f.Close(); err == nil {
+			err = cerr
+		}
+	}()
+
+	switch format {
+	case "json":
+		enc := json.NewEncoder(f)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(rep); err != nil {
+			return fmt.Errorf("export report: %w", err)
+		}
+	case "csv":
+		w := csv.NewWriter(f)
+		header := []string{"symbol", "direction", "entry_time", "expiry_time", "outcome", "reason"}
+		if err := w.Write(header); err != nil {
+			return fmt.Errorf("export report: %w", err)
+		}
+		for _, r := range rep.Results {
+			row := []string{
+				r.Symbol,
+				r.Direction,
+				r.EntryTime.Format(time.RFC3339),
+				r.ExpiryTime.Format(time.RFC3339),
+				r.Outcome,
+				r.Reason,
+			}
+			if err := w.Write(row); err != nil {
+				return fmt.Errorf("export report: %w", err)
+			}
+		}
+		w.Flush()
+		if err := w.Error(); err != nil {
+			return fmt.Errorf("export report: %w", err)
+		}
+	default:
+		return fmt.Errorf("export report: unsupported format %s", format)
+	}
+	return nil
+}

--- a/internal/delivery/signal_statsexporter_test.go
+++ b/internal/delivery/signal_statsexporter_test.go
@@ -1,0 +1,94 @@
+package delivery
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nomenarkt/signalengine/internal/usecase"
+)
+
+func sampleReport() usecase.BacktestReport {
+	return usecase.BacktestReport{
+		Results: []usecase.BacktestResult{
+			{
+				Symbol:     "EURUSD",
+				Direction:  "UP",
+				EntryTime:  time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC),
+				ExpiryTime: time.Date(2024, 1, 2, 3, 9, 5, 0, time.UTC),
+				Outcome:    "WIN",
+				Reason:     "test",
+			},
+		},
+		Total:  1,
+		Wins:   1,
+		Losses: 0,
+	}
+}
+
+func TestExportBacktestReport(t *testing.T) {
+	tmp := t.TempDir()
+	rep := sampleReport()
+
+	tests := []struct {
+		name      string
+		path      string
+		format    string
+		expectErr bool
+	}{
+		{name: "json by ext", path: filepath.Join(tmp, "r.json"), format: ""},
+		{name: "csv by ext", path: filepath.Join(tmp, "r.csv"), format: ""},
+		{name: "override format", path: filepath.Join(tmp, "r.json"), format: "csv"},
+		{name: "unwritable path", path: filepath.Join(tmp, "missing", "r.csv"), format: "", expectErr: true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			err := ExportBacktestReport(rep, tt.path, tt.format)
+			if tt.expectErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			data, err := os.ReadFile(tt.path)
+			if err != nil {
+				t.Fatalf("read file: %v", err)
+			}
+			switch format := tt.format; {
+			case format == "csv" || (format == "" && filepath.Ext(tt.path) == ".csv"):
+				r := csv.NewReader(strings.NewReader(string(data)))
+				recs, err := r.ReadAll()
+				if err != nil {
+					t.Fatalf("read csv: %v", err)
+				}
+				if len(recs) != len(rep.Results)+1 {
+					t.Fatalf("expected %d records, got %d", len(rep.Results)+1, len(recs))
+				}
+			default:
+				var out usecase.BacktestReport
+				if err := json.Unmarshal(data, &out); err != nil {
+					t.Fatalf("json parse: %v", err)
+				}
+				if out.Total != rep.Total {
+					t.Fatalf("expected total %d, got %d", rep.Total, out.Total)
+				}
+			}
+		})
+	}
+}
+
+func TestExportBacktestReport_Empty(t *testing.T) {
+	err := ExportBacktestReport(usecase.BacktestReport{}, filepath.Join(t.TempDir(), "r.json"), "")
+	if err == nil {
+		t.Fatalf("expected error for empty report")
+	}
+}


### PR DESCRIPTION
## Summary
- add helper to export backtest results to JSON or CSV
- cover exporter with unit tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6847112296088329b5b726adf80c5441