### PR TITLE
feat(docs): add SignalStatsExporter usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,25 @@ Follows Clean Architecture:
 Copy `.env.example` to `.env` and provide your API keys and settings. Ensure
 `FINAGE_API_KEY` is set for the market feed. The application will load
 variables from `.env` at startup.
+
+## SignalStatsExporter
+
+Backtest results can be saved using the `ExportBacktestReport` helper from the
+`internal/delivery` package. The function accepts a `BacktestReport`, the output
+file path, and a format.
+
+Supported formats:
+
+- `json`
+- `csv`
+
+```go
+rep := usecase.BacktestSignals(data, 3*time.Minute, 2*time.Minute)
+err := delivery.ExportBacktestReport(rep, "testdata/tmp/out.json", "json")
+if err != nil {
+    log.Fatal(err)
+}
+```
+
+Files are created at the path you pass in. Integration tests write the exported
+reports to `testdata/tmp/` for review.


### PR DESCRIPTION
## Summary
- document how to run the SignalStatsExporter

## Testing
- `go fmt ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6847159265f48329a3c8bda0f712fd4f