### PR TITLE
feat(usecase): add EMA and candlestick scoring

### DIFF
--- a/internal/usecase/candlestick_classifier_scorer.go
+++ b/internal/usecase/candlestick_classifier_scorer.go
@@ -1,0 +1,41 @@
+package usecase
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/nomenarkt/signalengine/internal/entity"
+	"github.com/nomenarkt/signalengine/internal/ports"
+)
+
+// ScoreCandlestickPatterns evaluates the latest candles for simple candlestick patterns.
+// It returns signals when bullish or bearish patterns are detected.
+func ScoreCandlestickPatterns(ctx context.Context, logger *slog.Logger, symbol string, candles []ports.Candle) []entity.Signal {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	logger.InfoContext(ctx, "score candlestick patterns", "symbol", symbol)
+
+	n := len(candles)
+	if n < 2 {
+		logger.WarnContext(ctx, "insufficient data", "candles", n)
+		return nil
+	}
+
+	last := n - 1
+	var signals []entity.Signal
+
+	if isBullishEngulfing(candles, last) || isBullishPinBar(candles[last]) {
+		signals = append(signals, entity.Signal{Symbol: symbol, Direction: "UP", Confidence: 0.5, TTL: time.Minute})
+	}
+	if isBearishEngulfing(candles, last) || isBearishPinBar(candles[last]) {
+		signals = append(signals, entity.Signal{Symbol: symbol, Direction: "DOWN", Confidence: 0.5, TTL: time.Minute})
+	}
+
+	if len(signals) == 0 {
+		logger.DebugContext(ctx, "no candlestick patterns found")
+	}
+
+	return signals
+}

--- a/internal/usecase/candlestick_classifier_scorer_test.go
+++ b/internal/usecase/candlestick_classifier_scorer_test.go
@@ -1,0 +1,78 @@
+package usecase
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/nomenarkt/signalengine/internal/ports"
+)
+
+func makeBullishEngulf() []ports.Candle {
+	base := time.Now()
+	return []ports.Candle{
+		{Symbol: "EURUSD", Time: base, Open: 1.0, High: 1.05, Low: 0.95, Close: 0.96},
+		{Symbol: "EURUSD", Time: base.Add(time.Minute), Open: 0.94, High: 1.1, Low: 0.9, Close: 1.05},
+	}
+}
+
+func makeBearishPin() []ports.Candle {
+	base := time.Now()
+	return []ports.Candle{
+		{Symbol: "EURUSD", Time: base, Open: 1, High: 1, Low: 1, Close: 1},
+		{Symbol: "EURUSD", Time: base.Add(time.Minute), Open: 1.0, High: 1.2, Low: 0.9, Close: 0.95},
+	}
+}
+
+func makeNeutral() []ports.Candle {
+	base := time.Now()
+	return []ports.Candle{
+		{Symbol: "EURUSD", Time: base, Open: 1, High: 1, Low: 1, Close: 1},
+		{Symbol: "EURUSD", Time: base.Add(time.Minute), Open: 1, High: 1, Low: 1, Close: 1},
+	}
+}
+
+func TestScoreCandlestickPatterns(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	t.Run("bullish engulfing", func(t *testing.T) {
+		candles := makeBullishEngulf()
+		sigs := ScoreCandlestickPatterns(ctx, logger, "EURUSD", candles)
+		if len(sigs) != 1 || sigs[0].Direction != "UP" {
+			t.Fatalf("expected UP signal, got %+v", sigs)
+		}
+	})
+
+	t.Run("bearish pinbar", func(t *testing.T) {
+		candles := makeBearishPin()
+		sigs := ScoreCandlestickPatterns(ctx, logger, "EURUSD", candles)
+		if len(sigs) != 1 || sigs[0].Direction != "DOWN" {
+			t.Fatalf("expected DOWN signal, got %+v", sigs)
+		}
+	})
+
+	t.Run("none logs", func(t *testing.T) {
+		candles := makeNeutral()
+		buf := &bytes.Buffer{}
+		h := slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+		log := slog.New(h)
+		ScoreCandlestickPatterns(ctx, log, "EURUSD", candles)
+		if !bytes.Contains(buf.Bytes(), []byte("no candlestick patterns found")) {
+			t.Errorf("expected debug log, got %s", buf.String())
+		}
+	})
+
+	t.Run("insufficient", func(t *testing.T) {
+		candles := makeBullishEngulf()[:1]
+		buf := &bytes.Buffer{}
+		log := slog.New(slog.NewTextHandler(buf, nil))
+		ScoreCandlestickPatterns(ctx, log, "EURUSD", candles)
+		if !bytes.Contains(buf.Bytes(), []byte("insufficient data")) {
+			t.Errorf("expected warn log, got %s", buf.String())
+		}
+	})
+}

--- a/internal/usecase/ema_interaction_scorer.go
+++ b/internal/usecase/ema_interaction_scorer.go
@@ -1,0 +1,52 @@
+package usecase
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/nomenarkt/signalengine/internal/entity"
+	"github.com/nomenarkt/signalengine/internal/ports"
+)
+
+// ScoreEMAInteractions looks for EMA crossovers between ema8 and ema21.
+// It returns binary trade signals when the fast EMA crosses the slow EMA.
+func ScoreEMAInteractions(ctx context.Context, logger *slog.Logger, symbol string, candles []ports.Candle, ema8, ema21 []float64) []entity.Signal {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	logger.InfoContext(ctx, "score EMA interactions", "symbol", symbol)
+
+	n := len(candles)
+	if n < 2 || n != len(ema8) || n != len(ema21) {
+		logger.WarnContext(ctx, "insufficient data", "candles", n, "ema8_len", len(ema8), "ema21_len", len(ema21))
+		return nil
+	}
+
+	prev := n - 2
+	last := n - 1
+	var signals []entity.Signal
+
+	if ema8[prev] <= ema21[prev] && ema8[last] > ema21[last] && candles[last].Close > ema8[last] {
+		signals = append(signals, entity.Signal{
+			Symbol:     symbol,
+			Direction:  "UP",
+			Confidence: 0.6,
+			TTL:        time.Minute,
+		})
+	}
+
+	if ema8[prev] >= ema21[prev] && ema8[last] < ema21[last] && candles[last].Close < ema8[last] {
+		signals = append(signals, entity.Signal{
+			Symbol:     symbol,
+			Direction:  "DOWN",
+			Confidence: 0.6,
+			TTL:        time.Minute,
+		})
+	}
+
+	if len(signals) == 0 {
+		logger.DebugContext(ctx, "no ema interaction signals")
+	}
+	return signals
+}

--- a/internal/usecase/ema_interaction_scorer_test.go
+++ b/internal/usecase/ema_interaction_scorer_test.go
@@ -1,0 +1,87 @@
+package usecase
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/nomenarkt/signalengine/internal/ports"
+)
+
+func makeBullishCross() ([]ports.Candle, []float64, []float64) {
+	base := time.Now()
+	candles := []ports.Candle{
+		{Symbol: "EURUSD", Time: base, Open: 1, High: 1, Low: 1, Close: 1},
+		{Symbol: "EURUSD", Time: base.Add(time.Minute), Open: 1.05, High: 1.1, Low: 1.0, Close: 1.1},
+	}
+	ema8 := []float64{1, 1.05}
+	ema21 := []float64{1, 1}
+	return candles, ema8, ema21
+}
+
+func makeBearishCross() ([]ports.Candle, []float64, []float64) {
+	base := time.Now()
+	candles := []ports.Candle{
+		{Symbol: "EURUSD", Time: base, Open: 1, High: 1, Low: 1, Close: 1},
+		{Symbol: "EURUSD", Time: base.Add(time.Minute), Open: 0.95, High: 1.0, Low: 0.9, Close: 0.9},
+	}
+	ema8 := []float64{1, 0.95}
+	ema21 := []float64{1, 1}
+	return candles, ema8, ema21
+}
+
+func makeNoCross() ([]ports.Candle, []float64, []float64) {
+	base := time.Now()
+	candles := []ports.Candle{
+		{Symbol: "EURUSD", Time: base, Open: 1, High: 1, Low: 1, Close: 1},
+		{Symbol: "EURUSD", Time: base.Add(time.Minute), Open: 1, High: 1, Low: 1, Close: 1},
+	}
+	ema8 := []float64{1, 1}
+	ema21 := []float64{1, 1}
+	return candles, ema8, ema21
+}
+
+func TestScoreEMAInteractions(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	t.Run("bullish cross", func(t *testing.T) {
+		candles, ema8, ema21 := makeBullishCross()
+		sigs := ScoreEMAInteractions(ctx, logger, "EURUSD", candles, ema8, ema21)
+		if len(sigs) != 1 || sigs[0].Direction != "UP" {
+			t.Fatalf("expected UP signal, got %+v", sigs)
+		}
+	})
+
+	t.Run("bearish cross", func(t *testing.T) {
+		candles, ema8, ema21 := makeBearishCross()
+		sigs := ScoreEMAInteractions(ctx, logger, "EURUSD", candles, ema8, ema21)
+		if len(sigs) != 1 || sigs[0].Direction != "DOWN" {
+			t.Fatalf("expected DOWN signal, got %+v", sigs)
+		}
+	})
+
+	t.Run("no cross logs", func(t *testing.T) {
+		candles, ema8, ema21 := makeNoCross()
+		buf := &bytes.Buffer{}
+		h := slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+		log := slog.New(h)
+		ScoreEMAInteractions(ctx, log, "EURUSD", candles, ema8, ema21)
+		if !bytes.Contains(buf.Bytes(), []byte("no ema interaction signals")) {
+			t.Errorf("expected debug log, got %s", buf.String())
+		}
+	})
+
+	t.Run("insufficient data", func(t *testing.T) {
+		candles, ema8, ema21 := makeBullishCross()
+		buf := &bytes.Buffer{}
+		log := slog.New(slog.NewTextHandler(buf, nil))
+		ScoreEMAInteractions(ctx, log, "EURUSD", candles[:1], ema8, ema21)
+		if !bytes.Contains(buf.Bytes(), []byte("insufficient data")) {
+			t.Errorf("expected warn log, got %s", buf.String())
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- add `ScoreEMAInteractions` for EMA crossover detection
- add `ScoreCandlestickPatterns` for simple candle pattern identification
- test EMA and candlestick scoring

## Testing
- `staticcheck ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68471a70614c8329bbb8854046e99e64