### PR TITLE
feat(usecase): add table-driven tests for scanner

### DIFF
--- a/internal/testutils/signal_pattern_data.go
+++ b/internal/testutils/signal_pattern_data.go
@@ -1,0 +1,63 @@
+package testutils
+
+import (
+	"time"
+
+	"github.com/nomenarkt/signalengine/internal/ports"
+)
+
+// MakeScannerDistinctData returns candles and indicators producing
+// unique signals from each scoring algorithm.
+func MakeScannerDistinctData() ([]ports.Candle, []float64, []float64, []float64) {
+	base := time.Now()
+	candles := make([]ports.Candle, 20)
+	rsi := make([]float64, 20)
+	ema8 := make([]float64, 20)
+	ema21 := make([]float64, 20)
+	for i := 0; i < 20; i++ {
+		candles[i] = ports.Candle{Symbol: "EURUSD", Time: base.Add(time.Duration(i) * time.Minute), Open: 1, High: 1, Low: 1, Close: 1}
+		rsi[i] = 50 - float64(i)
+		ema8[i] = 1
+		ema21[i] = 1
+	}
+	candles[16] = ports.Candle{Symbol: "EURUSD", Time: base.Add(16 * time.Minute), Open: 0.7, High: 0.8, Low: 0.5, Close: 0.6}
+	rsi[16] = 30
+	candles[17] = ports.Candle{Symbol: "EURUSD", Time: base.Add(17 * time.Minute), Open: 0.65, High: 0.75, Low: 0.55, Close: 0.6}
+	rsi[17] = 32
+	candles[18] = ports.Candle{Symbol: "EURUSD", Time: base.Add(18 * time.Minute), Open: 0.6, High: 0.65, Low: 0.45, Close: 0.5}
+	rsi[18] = 31
+	candles[19] = ports.Candle{Symbol: "EURUSD", Time: base.Add(19 * time.Minute), Open: 0.48, High: 0.9, Low: 0.4, Close: 0.8}
+	rsi[19] = 40
+
+	// EMA cross down distinct from candlestick bullish pattern
+	ema8[18] = 1.0
+	ema21[18] = 0.9
+	ema8[19] = 0.85
+	ema21[19] = 0.9
+	return candles, rsi, ema8, ema21
+}
+
+// MakeScannerDuplicateData returns candles and indicators that cause
+// duplicate signals from different scoring algorithms.
+func MakeScannerDuplicateData() ([]ports.Candle, []float64, []float64, []float64) {
+	base := time.Now()
+	candles := make([]ports.Candle, 20)
+	rsi := make([]float64, 20)
+	ema8 := make([]float64, 20)
+	ema21 := make([]float64, 20)
+	for i := 0; i < 18; i++ {
+		candles[i] = ports.Candle{Symbol: "EURUSD", Time: base.Add(time.Duration(i) * time.Minute), Open: 1, High: 1, Low: 1, Close: 1}
+		rsi[i] = 50
+		ema8[i] = 1
+		ema21[i] = 1
+	}
+	candles[18] = ports.Candle{Symbol: "EURUSD", Time: base.Add(18 * time.Minute), Open: 1.05, High: 1.1, Low: 0.95, Close: 1.0}
+	candles[19] = ports.Candle{Symbol: "EURUSD", Time: base.Add(19 * time.Minute), Open: 0.98, High: 1.15, Low: 0.95, Close: 1.1}
+	rsi[18] = 50
+	rsi[19] = 50
+	ema8[18] = 1
+	ema21[18] = 1
+	ema8[19] = 1.05
+	ema21[19] = 1
+	return candles, rsi, ema8, ema21
+}

--- a/internal/usecase/signal_pattern_scanner_test.go
+++ b/internal/usecase/signal_pattern_scanner_test.go
@@ -3,98 +3,66 @@ package usecase
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/nomenarkt/signalengine/internal/ports"
+	"github.com/nomenarkt/signalengine/internal/testutils"
 )
-
-func makeRSIDivData() ([]ports.Candle, []float64, []float64, []float64) {
-	base := time.Now()
-	candles := make([]ports.Candle, 20)
-	rsi := make([]float64, 20)
-	ema8 := make([]float64, 20)
-	ema21 := make([]float64, 20)
-	for i := 0; i < 20; i++ {
-		candles[i] = ports.Candle{Symbol: "EURUSD", Time: base.Add(time.Duration(i) * time.Minute), Open: 1, High: 1, Low: 1, Close: 1}
-		rsi[i] = 50 - float64(i)
-		ema8[i] = 1
-		ema21[i] = 1
-	}
-	candles[16].Open = 0.7
-	candles[16].High = 0.8
-	candles[16].Low = 0.5
-	candles[16].Close = 0.6
-	rsi[16] = 30
-
-	candles[17].Open = 0.65
-	candles[17].High = 0.75
-	candles[17].Low = 0.55
-	candles[17].Close = 0.6
-	rsi[17] = 32
-
-	candles[18].Open = 0.6
-	candles[18].High = 0.65
-	candles[18].Low = 0.45
-	candles[18].Close = 0.5
-	rsi[18] = 31
-
-	candles[19].Open = 0.48
-	candles[19].High = 0.9
-	candles[19].Low = 0.4
-	candles[19].Close = 0.8
-	rsi[19] = 40
-	return candles, rsi, ema8, ema21
-}
-
-func makeDupData() ([]ports.Candle, []float64, []float64, []float64) {
-	base := time.Now()
-	candles := make([]ports.Candle, 20)
-	rsi := make([]float64, 20)
-	ema8 := make([]float64, 20)
-	ema21 := make([]float64, 20)
-	for i := 0; i < 18; i++ {
-		candles[i] = ports.Candle{Symbol: "EURUSD", Time: base.Add(time.Duration(i) * time.Minute), Open: 1, High: 1, Low: 1, Close: 1}
-		rsi[i] = 50
-		ema8[i] = 1
-		ema21[i] = 1
-	}
-	candles[18] = ports.Candle{Symbol: "EURUSD", Time: base.Add(18 * time.Minute), Open: 1.05, High: 1.1, Low: 0.95, Close: 1.0}
-	candles[19] = ports.Candle{Symbol: "EURUSD", Time: base.Add(19 * time.Minute), Open: 1.0, High: 1.15, Low: 0.95, Close: 1.1}
-	rsi[18] = 50
-	rsi[19] = 50
-	ema8[18] = 1
-	ema21[18] = 1
-	ema8[19] = 1.05
-	ema21[19] = 1
-	return candles, rsi, ema8, ema21
-}
 
 func TestScanSignalPatterns(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("invalid input", func(t *testing.T) {
-		_, err := ScanSignalPatterns(ctx, nil, "EURUSD", make([]ports.Candle, 10), make([]float64, 10), make([]float64, 10), make([]float64, 9))
-		if err == nil {
-			t.Fatalf("expected error")
-		}
-	})
+	tests := []struct {
+		name    string
+		data    func() ([]ports.Candle, []float64, []float64, []float64)
+		want    int
+		wantErr bool
+	}{
+		{
+			name: "distinct",
+			data: testutils.MakeScannerDistinctData,
+			want: 3,
+		},
+		{
+			name: "duplicates",
+			data: testutils.MakeScannerDuplicateData,
+			want: 1,
+		},
+		{
+			name: "empty",
+			data: func() ([]ports.Candle, []float64, []float64, []float64) {
+				return nil, nil, nil, nil
+			},
+			wantErr: true,
+		},
+		{
+			name: "mismatched lengths",
+			data: func() ([]ports.Candle, []float64, []float64, []float64) {
+				return make([]ports.Candle, 10), make([]float64, 10), make([]float64, 9), make([]float64, 10)
+			},
+			wantErr: true,
+		},
+	}
 
-	t.Run("rsi divergence", func(t *testing.T) {
-		candles, rsi, ema8, ema21 := makeRSIDivData()
-		sigs, err := ScanSignalPatterns(ctx, nil, "EURUSD", candles, rsi, ema8, ema21)
-		if err != nil || len(sigs) != 2 {
-			t.Fatalf("unexpected result: %v %v", sigs, err)
-		}
-	})
-
-	t.Run("deduplicate", func(t *testing.T) {
-		candles, rsi, ema8, ema21 := makeDupData()
-		sigs, err := ScanSignalPatterns(ctx, nil, "EURUSD", candles, rsi, ema8, ema21)
-		if err != nil {
-			t.Fatalf("scan: %v", err)
-		}
-		if len(sigs) != 1 {
-			t.Fatalf("expected 1 signal, got %d", len(sigs))
-		}
-	})
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			candles, rsi, ema8, ema21 := tt.data()
+			sigs, err := ScanSignalPatterns(ctx, nil, "EURUSD", candles, rsi, ema8, ema21)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				if sigs != nil {
+					t.Fatalf("expected nil signals, got %v", sigs)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(sigs) != tt.want {
+				t.Fatalf("expected %d signals, got %d", tt.want, len(sigs))
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary
- add distinct and duplicate scenario helpers for the signal pattern scanner
- rewrite `signal_pattern_scanner_test.go` with table-driven cases

## Testing
- `go test ./...`
- `staticcheck ./...` *(fails: module requires at least go1.24.1)*

------
https://chatgpt.com/codex/tasks/task_e_6847298ba958832982177a13ef6f3605